### PR TITLE
Multiple fixes & additions

### DIFF
--- a/juniper.lisp
+++ b/juniper.lisp
@@ -131,7 +131,7 @@
                                                           ,endpoint (mkstr ,symbolic-name))))
 			  ("query"
 			   `(push (cons ,name (mkstr ,symbolic-name))
-					,query-params))
+                                  ,query-params))
 			  ("header"
 			   `(push (cons ,name (mkstr ,symbolic-name))
 				  ,headers))
@@ -153,7 +153,7 @@
 	(push '&key optional))
       (when *required-as-keyword*
 	(push '&key required)) ; required comes first so applies to optional as well
-      ; maybe split this into many functions?
+      ;; maybe split this into many functions?
       `(defun ,(lisp-symbol (field :|operationId| (cdr op)))
 	   ,(append required optional
 	     `(&aux
@@ -209,7 +209,7 @@
 		      (field :|openapi|)
 		      (error "Cannot find version field in schema.")))
 
-	 ; FIXME we only use the first protocol presented
+         ;; FIXME we only use the first protocol presented
 	 (*proto* (or proto (car (field :|schemes|))
 		      (error "Cannot find protocol in schema.")))
 	 (*host* (or host (field :|host|)

--- a/juniper.lisp
+++ b/juniper.lisp
@@ -25,7 +25,7 @@
 
 ;;; utilities
 ;; `mkstr` and `symb` are from Let over Lambda, which I believe were taken from On Lisp
-(eval-when (compile load eval)
+(eval-when (:compile-toplevel :load-toplevel :execute)
   (defun mkstr (&rest args)
     (with-output-to-string (s)
       (dolist (a args) (princ a s))))

--- a/juniper.lisp
+++ b/juniper.lisp
@@ -126,9 +126,9 @@
 		  `(if ,(if is-required t supplied-p)
 		       ,(switch (in :test #'string=)
 			  ("path"
-			   `(setf ,base-path
-				  (cl-ppcre:regex-replace ,(format nil "{~a}" name)
-							  ,base-path (mkstr ,symbolic-name))))
+			   `(setf ,endpoint
+                                  (cl-ppcre:regex-replace ,(format nil "{~a}" name)
+                                                          ,endpoint (mkstr ,symbolic-name))))
 			  ("query"
 			   `(push (cons ,name (mkstr ,symbolic-name))
 					,query-params))

--- a/juniper.lisp
+++ b/juniper.lisp
@@ -110,7 +110,7 @@
 ; FIXME barely readable mess
 (defun function-for-op (op &aux required optional assistance-code)
   (with-gensyms (url query-params headers body uses-form proto host port base-path
-                     endpoint response response-string status-code response-headers default-headers)
+                     endpoint response-string status-code response-headers default-headers)
     (labels ((parse-parameter (param)
 	       (let* ((name (field :|name| param))
 		      (symbolic-name (lisp-symbol name))


### PR DESCRIPTION
Hello,

Nice little macro you have here. I've had to use it for a swagger spec, and it worked pretty well. Except I needed some stuff in there as well. So I decided to add these & also fix some of the FIXME comments.

Apply whatever you want from it.

### Fixes
- Pseudo-dynamic request content type instead of the hardcoded `application/json`-string
- Deprecated warning for `eval-when`

#### The JSON assumption & body response mapping
Drakma has a builtin variable [`*text-content-types*`](https://edicl.github.io/drakma/#*text-content-types*) which says what body content is definitely text. So since drakma automatically maps the response body to characters based on the content type header, I've added a `let`-binding after the generated URL which overrides the default `drakma:*text-content-types*` to ensure correct behavior for json decoding which comes after. So leaving the default behavior the same, while the assumed json body is dropped. The generated function now also returns the string/byte-array when the content type header is not json as its mime subtype.

#### `base-path` to `endpoint`
Idk if you noticed this, but the parameters for the generated functions were applied to the `base-path`, not to the `endpoint`, which seems erroneous? So I put that fix in a separate commit as well. 

In my case at least I got an error, because the endpoints included the path variables, not the basepath...

### Additions
#### `default-headers` keyword
The keyword allows to add in `:additional-headers` some default headers. The headers will be overwritten by `headers` when applicable. I needed to add some custom authentication headers, so I added this one.
#### Optional `export` keyword
Setting the keyword to `t` automatically adds an `export` statement for the function symbol. Defaults to `nil`, so it does not mess with the existing behavior. I wanted a separate package with exported function symbols, so I added this.

Thanks in advance for reviewing the PR.